### PR TITLE
Add detailed mail config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ MAILTO=""               # your "to:" mail address
 MAILSERVER=""           # your smtp server address
 MAILUSER=""             # your user name from smtp server
 MAILPASS=""             # your password from smtp server
+MAILPORT=""             # OPTIONAL smtp server port to be used 
+MAILENCRYPT=""          # OPTIONAL encryption method to be used. Valid values are TLS, TLS-optional, TLS-optional-strict, TLS-on-connect. 
 
 ## alerting settings
 SATPINGFREQ=3600        # in case satellite scores are below threshold, 


### PR DESCRIPTION
My mail servers requires TLS and port parameters to be set, however the storj-system-health.sh did not seem to support this. So I've made the following changes:
- Introduced two optional mail parameters `MAILPORT` and `MAILENCRYPT`
- Refactored the mail sending part, so that a universal mail command (called `SWAKSCMD`) is constructed in advance, taking into consideration the `MAILPORT` and `MAILENCRYPT` variables. Then all mails are being sent via `SWAKSCMD`
- Also added some basic errorhandilng for parameter values. 